### PR TITLE
Add design doc for EC2NodeClass role mutability

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -506,17 +506,14 @@ spec:
                   type: object
                 role:
                   description: |-
-                    Role is the AWS identity that nodes use. This field is immutable.
+                    Role is the AWS identity that nodes use. This field may be updated.
                     This field is mutually exclusive from instanceProfile.
-                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
-                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
-                    for the old instance profiles on an update.
+                    Karpenter creates a new instance profile for each role value to avoid
+                    disrupting running nodes when the role changes.
                   type: string
                   x-kubernetes-validations:
                     - message: role cannot be empty
                       rule: self != ''
-                    - message: immutable field changed
-                      rule: self == oldSelf
                 securityGroupSelectorTerms:
                   description: SecurityGroupSelectorTerms is a list of security group selector terms. The terms are ORed.
                   items:

--- a/designs/spec-role-mutation.md
+++ b/designs/spec-role-mutation.md
@@ -1,0 +1,27 @@
+# EC2NodeClass spec.role Mutability
+
+This document outlines a proposal for making `spec.role` on `EC2NodeClass` resources mutable.
+
+## Background
+
+Currently `spec.role` is immutable. Karpenter manages an instance profile for each EC2NodeClass when the role is specified. The profile is created at reconciliation time and deleted during finalization.
+
+Users have requested that the role be editable after creation so that the node permissions can be updated without recreating the entire EC2NodeClass.
+
+## Goals
+
+* Allow updates to `spec.role` in place.
+* Avoid disrupting running instances that still use the old role.
+* Automatically clean up instance profiles that are no longer referenced by nodes.
+
+## Proposed Approach
+
+1. **Multiple Instance Profiles**  
+   Instead of a single profile per EC2NodeClass, tag each profile with the owning EC2NodeClass name. When the role is updated, create a new instance profile with the new role and tag it accordingly.
+2. **Garbage Collection**  
+   Periodically list instance profiles owned by the EC2NodeClass and query EC2 for instances using each profile. Profiles with no running instances are deleted.
+3. **Finalization**  
+   During EC2NodeClass deletion, remove all owned instance profiles once they are unused. The resource finalizer waits until all profiles are cleaned up.
+
+This approach ensures running nodes keep their existing role until they are replaced while enabling the EC2NodeClass to reference a new role for newly launched nodes.
+

--- a/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/pkg/apis/crds/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -503,17 +503,14 @@ spec:
                   type: object
                 role:
                   description: |-
-                    Role is the AWS identity that nodes use. This field is immutable.
+                    Role is the AWS identity that nodes use. This field may be updated.
                     This field is mutually exclusive from instanceProfile.
-                    Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
-                    This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
-                    for the old instance profiles on an update.
+                    Karpenter creates a new instance profile for each role value to avoid
+                    disrupting running nodes when the role changes.
                   type: string
                   x-kubernetes-validations:
                     - message: role cannot be empty
                       rule: self != ''
-                    - message: immutable field changed
-                      rule: self == oldSelf
                 securityGroupSelectorTerms:
                   description: SecurityGroupSelectorTerms is a list of security group selector terms. The terms are ORed.
                   items:

--- a/pkg/apis/v1/ec2nodeclass.go
+++ b/pkg/apis/v1/ec2nodeclass.go
@@ -77,13 +77,11 @@ type EC2NodeClassSpec struct {
 	// this UserData to ensure nodes are being provisioned with the correct configuration.
 	// +optional
 	UserData *string `json:"userData,omitempty"`
-	// Role is the AWS identity that nodes use. This field is immutable.
+	// Role is the AWS identity that nodes use. This field may be updated.
 	// This field is mutually exclusive from instanceProfile.
-	// Marking this field as immutable avoids concerns around terminating managed instance profiles from running instances.
-	// This field may be made mutable in the future, assuming the correct garbage collection and drift handling is implemented
-	// for the old instance profiles on an update.
+	// Karpenter manages a distinct instance profile for each unique role to
+	// avoid disrupting running nodes when the role changes.
 	// +kubebuilder:validation:XValidation:rule="self != ''",message="role cannot be empty"
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="immutable field changed"
 	// +optional
 	Role string `json:"role,omitempty"`
 	// InstanceProfile is the AWS entity that instances use.
@@ -498,7 +496,8 @@ func (in *EC2NodeClass) Hash() string {
 }
 
 func (in *EC2NodeClass) InstanceProfileName(clusterName, region string) string {
-	return fmt.Sprintf("%s_%d", clusterName, lo.Must(hashstructure.Hash(fmt.Sprintf("%s%s", region, in.Name), hashstructure.FormatV2, nil)))
+	hashInput := fmt.Sprintf("%s%s%s", region, in.Name, in.Spec.Role)
+	return fmt.Sprintf("%s_%d", clusterName, lo.Must(hashstructure.Hash(hashInput, hashstructure.FormatV2, nil)))
 }
 
 func (in *EC2NodeClass) InstanceProfileRole() string {

--- a/pkg/aws/sdk.go
+++ b/pkg/aws/sdk.go
@@ -51,6 +51,8 @@ type IAMAPI interface {
 	AddRoleToInstanceProfile(context.Context, *iam.AddRoleToInstanceProfileInput, ...func(*iam.Options)) (*iam.AddRoleToInstanceProfileOutput, error)
 	TagInstanceProfile(context.Context, *iam.TagInstanceProfileInput, ...func(*iam.Options)) (*iam.TagInstanceProfileOutput, error)
 	RemoveRoleFromInstanceProfile(context.Context, *iam.RemoveRoleFromInstanceProfileInput, ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error)
+	ListInstanceProfiles(context.Context, *iam.ListInstanceProfilesInput, ...func(*iam.Options)) (*iam.ListInstanceProfilesOutput, error)
+	ListInstanceProfileTags(context.Context, *iam.ListInstanceProfileTagsInput, ...func(*iam.Options)) (*iam.ListInstanceProfileTagsOutput, error)
 }
 type EKSAPI interface {
 	DescribeCluster(context.Context, *eks.DescribeClusterInput, ...func(*eks.Options)) (*eks.DescribeClusterOutput, error)

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -176,8 +176,19 @@ func (c *Controller) finalize(ctx context.Context, nodeClass *v1.EC2NodeClass) (
 		return reconcile.Result{RequeueAfter: time.Minute * 10}, nil // periodically fire the event
 	}
 	if nodeClass.Spec.Role != "" {
-		if err := c.instanceProfileProvider.Delete(ctx, nodeClass.InstanceProfileName(options.FromContext(ctx).ClusterName, c.region)); err != nil {
-			return reconcile.Result{}, fmt.Errorf("deleting instance profile, %w", err)
+		tags := map[string]string{
+			v1.EKSClusterNameTagKey: options.FromContext(ctx).ClusterName,
+			v1.NodeClassTagKey:      nodeClass.Name,
+			v1.LabelTopologyRegion:  c.region,
+		}
+		profiles, err := c.instanceProfileProvider.List(ctx, tags)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("listing instance profiles, %w", err)
+		}
+		for _, name := range profiles {
+			if err := c.instanceProfileProvider.Delete(ctx, name); err != nil {
+				return reconcile.Result{}, fmt.Errorf("deleting instance profile, %w", err)
+			}
 		}
 	}
 	if err := c.launchTemplateProvider.DeleteAll(ctx, nodeClass); err != nil {

--- a/pkg/controllers/nodeclass/instanceprofile.go
+++ b/pkg/controllers/nodeclass/instanceprofile.go
@@ -41,15 +41,17 @@ func NewInstanceProfileReconciler(instanceProfileProvider instanceprofile.Provid
 func (ip *InstanceProfile) Reconcile(ctx context.Context, nodeClass *v1.EC2NodeClass) (reconcile.Result, error) {
 	if nodeClass.Spec.Role != "" {
 		profileName := nodeClass.InstanceProfileName(options.FromContext(ctx).ClusterName, ip.region)
-		if err := ip.instanceProfileProvider.Create(
-			ctx,
-			profileName,
-			nodeClass.InstanceProfileRole(),
-			nodeClass.InstanceProfileTags(options.FromContext(ctx).ClusterName, ip.region),
-		); err != nil {
-			return reconcile.Result{}, fmt.Errorf("creating instance profile, %w", err)
+		if nodeClass.Status.InstanceProfile != profileName {
+			if err := ip.instanceProfileProvider.Create(
+				ctx,
+				profileName,
+				nodeClass.InstanceProfileRole(),
+				nodeClass.InstanceProfileTags(options.FromContext(ctx).ClusterName, ip.region),
+			); err != nil {
+				return reconcile.Result{}, fmt.Errorf("creating instance profile, %w", err)
+			}
+			nodeClass.Status.InstanceProfile = profileName
 		}
-		nodeClass.Status.InstanceProfile = profileName
 	} else {
 		nodeClass.Status.InstanceProfile = lo.FromPtr(nodeClass.Spec.InstanceProfile)
 	}

--- a/pkg/fake/iamapi.go
+++ b/pkg/fake/iamapi.go
@@ -40,6 +40,8 @@ type IAMAPIBehavior struct {
 	AddRoleToInstanceProfileBehavior      MockedFunction[iam.AddRoleToInstanceProfileInput, iam.AddRoleToInstanceProfileOutput]
 	TagInstanceProfileBehavior            MockedFunction[iam.TagInstanceProfileInput, iam.TagInstanceProfileOutput]
 	RemoveRoleFromInstanceProfileBehavior MockedFunction[iam.RemoveRoleFromInstanceProfileInput, iam.RemoveRoleFromInstanceProfileOutput]
+	ListInstanceProfilesBehavior          MockedFunction[iam.ListInstanceProfilesInput, iam.ListInstanceProfilesOutput]
+	ListInstanceProfileTagsBehavior       MockedFunction[iam.ListInstanceProfileTagsInput, iam.ListInstanceProfileTagsOutput]
 }
 
 type IAMAPI struct {
@@ -61,6 +63,8 @@ func (s *IAMAPI) Reset() {
 	s.DeleteInstanceProfileBehavior.Reset()
 	s.AddRoleToInstanceProfileBehavior.Reset()
 	s.RemoveRoleFromInstanceProfileBehavior.Reset()
+	s.ListInstanceProfilesBehavior.Reset()
+	s.ListInstanceProfileTagsBehavior.Reset()
 	s.InstanceProfiles = map[string]*iamtypes.InstanceProfile{}
 }
 
@@ -194,6 +198,32 @@ func (s *IAMAPI) RemoveRoleFromInstanceProfile(_ context.Context, input *iam.Rem
 			Code: "NoSuchEntity",
 			Message: fmt.Sprintf("Instance Profile %s cannot be found",
 				aws.ToString(input.InstanceProfileName)),
+		}
+	})
+}
+
+func (s *IAMAPI) ListInstanceProfiles(_ context.Context, input *iam.ListInstanceProfilesInput, _ ...func(*iam.Options)) (*iam.ListInstanceProfilesOutput, error) {
+	return s.ListInstanceProfilesBehavior.Invoke(input, func(*iam.ListInstanceProfilesInput) (*iam.ListInstanceProfilesOutput, error) {
+		s.Lock()
+		defer s.Unlock()
+		profiles := make([]iamtypes.InstanceProfile, 0, len(s.InstanceProfiles))
+		for _, p := range s.InstanceProfiles {
+			profiles = append(profiles, *p)
+		}
+		return &iam.ListInstanceProfilesOutput{InstanceProfiles: profiles}, nil
+	})
+}
+
+func (s *IAMAPI) ListInstanceProfileTags(_ context.Context, input *iam.ListInstanceProfileTagsInput, _ ...func(*iam.Options)) (*iam.ListInstanceProfileTagsOutput, error) {
+	return s.ListInstanceProfileTagsBehavior.Invoke(input, func(*iam.ListInstanceProfileTagsInput) (*iam.ListInstanceProfileTagsOutput, error) {
+		s.Lock()
+		defer s.Unlock()
+		if profile, ok := s.InstanceProfiles[aws.ToString(input.InstanceProfileName)]; ok {
+			return &iam.ListInstanceProfileTagsOutput{Tags: profile.Tags}, nil
+		}
+		return nil, &smithy.GenericAPIError{
+			Code:    "NoSuchEntity",
+			Message: fmt.Sprintf("Instance Profile %s cannot be found", aws.ToString(input.InstanceProfileName)),
 		}
 	})
 }

--- a/pkg/providers/instanceprofile/instanceprofile.go
+++ b/pkg/providers/instanceprofile/instanceprofile.go
@@ -34,6 +34,7 @@ type Provider interface {
 	Get(context.Context, string) (*iamtypes.InstanceProfile, error)
 	Create(context.Context, string, string, map[string]string) error
 	Delete(context.Context, string) error
+	List(context.Context, map[string]string) ([]string, error)
 }
 
 type DefaultProvider struct {
@@ -130,4 +131,34 @@ func (p *DefaultProvider) Delete(ctx context.Context, instanceProfileName string
 	}
 	p.cache.Delete(instanceProfileName)
 	return nil
+}
+
+func (p *DefaultProvider) List(ctx context.Context, tags map[string]string) ([]string, error) {
+	paginator := iam.NewListInstanceProfilesPaginator(p.iamapi, &iam.ListInstanceProfilesInput{})
+	var names []string
+	for paginator.HasMorePages() {
+		out, err := paginator.NextPage(ctx)
+		if err != nil {
+			return names, err
+		}
+		for _, profile := range out.InstanceProfiles {
+			tagOut, err := p.iamapi.ListInstanceProfileTags(ctx, &iam.ListInstanceProfileTagsInput{InstanceProfileName: profile.InstanceProfileName})
+			if err != nil {
+				return names, err
+			}
+			if matchesAllTags(tagOut.Tags, tags) {
+				names = append(names, lo.FromPtr(profile.InstanceProfileName))
+			}
+		}
+	}
+	return names, nil
+}
+
+func matchesAllTags(tags []iamtypes.Tag, wanted map[string]string) bool {
+	for k, v := range wanted {
+		if !lo.ContainsBy(tags, func(t iamtypes.Tag) bool { return lo.FromPtr(t.Key) == k && lo.FromPtr(t.Value) == v }) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- add a design document describing how to make `spec.role` mutable
- allow `spec.role` updates by hashing the role into the instance profile name
- manage new instance profiles on role change
- delete all instance profiles for a node class during finalization

## Testing
- `make test` *(fails: Get "https://storage.googleapis.com/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68410f7635b08330ad3cc6d3316cd5b5